### PR TITLE
fix: Build fails if parcel-resolver "packageExports" config is "true'

### DIFF
--- a/packages/storybook-builder-parcel/gen-iframe-modern.js
+++ b/packages/storybook-builder-parcel/gen-iframe-modern.js
@@ -22,7 +22,7 @@ const TEMPLATE = `<!DOCTYPE html>
     <!-- [BODY HTML SNIPPET HERE] -->
     <div id="storybook-root"></div>
     <div id="storybook-docs"></div>
-    <script type="module" src="npm:@storybook/preview/dist/runtime.js"></script>
+    <script type="module" src="npm:@storybook/preview"></script>
     <script type="module" src="preview.js"></script>
   </body>
 </html>


### PR DESCRIPTION
# Bug

If parcel-resolver is configured to respect package.json#exports then build fails with this [2] error.

[1]
In package.json:
```
    "@parcel/resolver-default": {
        "packageExports": true
    },
```

[2]

<img width="714" alt="image" src="https://github.com/user-attachments/assets/d0cf815f-3769-4170-a5c1-0170463165a2">
